### PR TITLE
fix: add default exports condition for pnpm v10 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "types": "./dist/types.d.mts",
-      "import": "./dist/module.mjs"
+      "import": "./dist/module.mjs",
+      "default": "./dist/module.mjs"
     }
   },
   "main": "./dist/module.mjs",


### PR DESCRIPTION
## Summary

- Adds a `"default"` fallback condition to the `package.json` `exports` field, fixing `ERR_PACKAGE_PATH_NOT_EXPORTED` when installing with pnpm v10

## Root cause

The `exports` field only had an `"import"` condition. When `nuxt module add` performs a CJS-style `require.resolve()` check after installation, pnpm v10's strict module resolution (which ignores the `main` field when `exports` is present) fails because there's no matching CJS condition. Adding `"default"` provides a catch-all fallback that works for both ESM and CJS resolution.

Closes #274